### PR TITLE
Clarify Foundry product labels in web UI

### DIFF
--- a/web/src/app/api/products/route.ts
+++ b/web/src/app/api/products/route.ts
@@ -1,28 +1,7 @@
 import { NextResponse } from 'next/server';
 import path from 'path';
 import fs from 'fs';
-
-// Hard-coded fallback product list
-const FALLBACK_PRODUCTS = [
-  'Microsoft-Foundry',
-  'AI-Foundry',
-  'AOAI-V2',
-  'Agent-Service',
-  'Model-Inference',
-  'AML',
-  'Cog-speech-service',
-  'Cog-document-intelligence',
-  'Cog-language-service',
-  'Cog-translator',
-  'Cog-content-safety',
-  'Cog-computer-vision',
-  'Cog-custom-vision-service',
-  'IoT-iot-hub',
-  'IoT-iot-edge',
-  'IoT-iot-dps',
-  'IoT-iot-central',
-  'IoT-iot-hub-device-update'
-];
+import { FALLBACK_PRODUCTS, PRODUCT_LABELS } from '@/lib/products';
 
 interface TargetConfig {
   topic_name: string;
@@ -40,6 +19,7 @@ export async function GET() {
       console.error(`Config file not found at: ${configPath}, using fallback products`);
       return NextResponse.json({ 
         products: FALLBACK_PRODUCTS,
+        labels: PRODUCT_LABELS,
         source: 'fallback',
         error: 'Config file not found'
       });
@@ -65,6 +45,7 @@ export async function GET() {
       console.error('No topic_name found in config file, using fallback products');
       return NextResponse.json({ 
         products: FALLBACK_PRODUCTS,
+        labels: PRODUCT_LABELS,
         source: 'fallback',
         error: 'No topics found in config'
       });
@@ -72,6 +53,7 @@ export async function GET() {
 
     return NextResponse.json({ 
       products,
+      labels: PRODUCT_LABELS,
       source: 'config',
       count: products.length
     });
@@ -80,6 +62,7 @@ export async function GET() {
     console.error('Error reading target_config.json:', error);
     return NextResponse.json({ 
       products: FALLBACK_PRODUCTS,
+      labels: PRODUCT_LABELS,
       source: 'fallback',
       error: error instanceof Error ? error.message : 'Unknown error'
     });

--- a/web/src/app/page.tsx
+++ b/web/src/app/page.tsx
@@ -6,28 +6,7 @@ import Filters from '@/components/Filters';
 import { Pagination } from '@/components/Pagination';
 import UpdateCard from '@/components/UpdateCard';
 import { useSession, signOut } from 'next-auth/react';
-
-// Fallback product list
-const FALLBACK_PRODUCTS = [
-  'Microsoft-Foundry',
-  'AI-Foundry',
-  'AOAI-V2',
-  'Agent-Service',
-  'Model-Inference',
-  'AML',
-  'Cog-speech-service',
-  'Cog-document-intelligence',
-  'Cog-language-service',
-  'Cog-translator',
-  'Cog-content-safety',
-  'Cog-computer-vision',
-  'Cog-custom-vision-service',
-  'IoT-iot-hub',
-  'IoT-iot-edge',
-  'IoT-iot-dps',
-  'IoT-iot-central',
-  'IoT-iot-hub-device-update'
-];
+import { DEFAULT_PRODUCT, FALLBACK_PRODUCTS, PRODUCT_LABELS } from '@/lib/products';
 
 async function getProducts() {
   try {
@@ -40,7 +19,10 @@ async function getProducts() {
 
     if (!response.ok) {
       console.error('Failed to fetch products, using fallback');
-      return FALLBACK_PRODUCTS;
+      return {
+        products: FALLBACK_PRODUCTS,
+        labels: PRODUCT_LABELS
+      };
     }
 
     const data = await response.json();
@@ -49,17 +31,23 @@ async function getProducts() {
       console.warn('Products API returned fallback:', data.error);
     }
     
-    return data.products || FALLBACK_PRODUCTS;
+    return {
+      products: data.products || FALLBACK_PRODUCTS,
+      labels: data.labels || PRODUCT_LABELS
+    };
   } catch (error) {
     console.error('Error fetching products:', error);
-    return FALLBACK_PRODUCTS;
+    return {
+      products: FALLBACK_PRODUCTS,
+      labels: PRODUCT_LABELS
+    };
   }
 }
 
 async function getUpdates(product: string, language: string, page: number, updateType: 'single' | 'weekly') {
   try {
     const params = new URLSearchParams({
-      product: product || 'Microsoft-Foundry',
+      product: product || DEFAULT_PRODUCT,
       language: language || 'Chinese',
       page: page.toString(),
       updateType: updateType
@@ -131,6 +119,7 @@ export default function Home({ searchParams }: { searchParams: { product?: strin
 
   const [updates, setUpdates] = React.useState<Update[]>([]);
   const [products, setProducts] = React.useState<string[]>(FALLBACK_PRODUCTS);
+  const [productLabels, setProductLabels] = React.useState<Record<string, string>>(PRODUCT_LABELS);
   const [currentProduct, setCurrentProduct] = React.useState<string>(searchParams.product || FALLBACK_PRODUCTS[0]);
   const [pagination, setPagination] = React.useState({
     currentPage: 1,
@@ -157,8 +146,9 @@ export default function Home({ searchParams }: { searchParams: { product?: strin
   // Fetch products on mount
   React.useEffect(() => {
     async function fetchProducts() {
-      const productList = await getProducts();
+      const { products: productList, labels } = await getProducts();
       setProducts(productList);
+      setProductLabels(labels);
       
       // If no product in URL, set default to first product from config
       if (!searchParams.product && productList.length > 0) {
@@ -218,6 +208,7 @@ export default function Home({ searchParams }: { searchParams: { product?: strin
         <div className="flex justify-between items-center mb-4">
           <Filters 
             products={products}
+            productLabels={productLabels}
             languages={['Chinese', 'English']}
           />
           <div className="flex items-center justify-end">

--- a/web/src/components/Filters.tsx
+++ b/web/src/components/Filters.tsx
@@ -6,9 +6,10 @@ import { useRouter, useSearchParams } from 'next/navigation';
 interface FiltersProps {
   products: string[];
   languages: string[];
+  productLabels?: Record<string, string>;
 }
 
-export default function Filters({ products, languages }: FiltersProps) {
+export default function Filters({ products, languages, productLabels = {} }: FiltersProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
 
@@ -88,7 +89,7 @@ export default function Filters({ products, languages }: FiltersProps) {
         >
           {products.map(product => (
             <option key={product} value={product} className="bg-background-primary text-text-secondary">
-              {product}
+              {productLabels[product] || product}
             </option>
           ))}
         </select>

--- a/web/src/lib/products.ts
+++ b/web/src/lib/products.ts
@@ -1,0 +1,49 @@
+export const DEFAULT_PRODUCT = 'Microsoft-Foundry';
+
+// Topic ids are stored in Cosmos DB and target_config.json. Keep ids stable,
+// and use labels to make the current Foundry/classic split clear in the UI.
+export const FALLBACK_PRODUCTS = [
+  'Microsoft-Foundry',
+  'AI-Foundry',
+  'AOAI-V2',
+  'Agent-Service',
+  'Model-Inference',
+  'AML',
+  'Cog-speech-service',
+  'Cog-content-understanding',
+  'Cog-computer-vision',
+  'Cog-content-safety',
+  'Cog-custom-vision-service',
+  'Cog-document-intelligence',
+  'Cog-language-service',
+  'Cog-translator',
+  'IoT-iot-central',
+  'IoT-iot-develop',
+  'IoT-iot-dps',
+  'IoT-iot-edge',
+  'IoT-iot-hub-device-update',
+  'IoT-iot-hub'
+];
+
+export const PRODUCT_LABELS: Record<string, string> = {
+  'Microsoft-Foundry': 'Microsoft Foundry (new)',
+  'AI-Foundry': 'AI Foundry / classic broad',
+  'AOAI-V2': 'Foundry classic OpenAI',
+  'Agent-Service': 'Foundry classic Agents',
+  'Model-Inference': 'Model Inference (legacy)',
+  AML: 'Azure Machine Learning',
+  'Cog-speech-service': 'Speech service',
+  'Cog-content-understanding': 'Content Understanding',
+  'Cog-computer-vision': 'Computer Vision',
+  'Cog-content-safety': 'Content Safety',
+  'Cog-custom-vision-service': 'Custom Vision',
+  'Cog-document-intelligence': 'Document Intelligence',
+  'Cog-language-service': 'Language service',
+  'Cog-translator': 'Translator',
+  'IoT-iot-central': 'IoT Central',
+  'IoT-iot-develop': 'IoT development',
+  'IoT-iot-dps': 'IoT DPS',
+  'IoT-iot-edge': 'IoT Edge',
+  'IoT-iot-hub-device-update': 'Device Update for IoT Hub',
+  'IoT-iot-hub': 'IoT Hub'
+};


### PR DESCRIPTION
## Summary
- Move the web fallback product list into a shared registry
- Add display labels that distinguish new Foundry coverage from classic/legacy coverage
- Return labels from `/api/products` and render labels in the product filter while keeping the stored topic ids stable

## Validation
- `npm run build` with dummy required env vars
- `git diff --check`

## Notes
- `npm run lint` currently prompts to initialize ESLint in this repo, so it is not usable as a non-interactive validation gate yet.
- This PR intentionally does not rename Cosmos topic ids; the labels clarify existing data without breaking queries.