### PR TITLE
Protect usage stats API

### DIFF
--- a/mcp_server/eyesondocs_mcp_server_http_search_fetch.py
+++ b/mcp_server/eyesondocs_mcp_server_http_search_fetch.py
@@ -10,12 +10,14 @@ mcp = FastMCP("doc_updates")
 API_BASE = "https://docs.westiedoubao.com/api"
 USER_AGENT = "doc-updates-app/1.0"
 
-async def make_api_request(url: str) -> dict[str, Any] | None:
+async def make_api_request(url: str, extra_headers: Optional[dict[str, str]] = None) -> dict[str, Any] | None:
     """向API发送请求，并进行适当的错误处理。"""
     headers = {
         "User-Agent": USER_AGENT,
         "Accept": "application/json"
     }
+    if extra_headers:
+        headers.update(extra_headers)
     async with httpx.AsyncClient() as client:
         try:
             response = await client.get(url, headers=headers, timeout=30.0)
@@ -154,7 +156,7 @@ async def get_usage_stats(
     if query_string:
         url = f"{url}?{query_string}"
     
-    data = await make_api_request(url)
+    data = await make_api_request(url, extra_headers={"x-admin-password": password})
     
     if not data or "error" in data:
         return f"无法获取使用统计数据：{data.get('error', '未知错误')}"

--- a/mcp_server/eyesondocs_mcp_server_http_streamable.py
+++ b/mcp_server/eyesondocs_mcp_server_http_streamable.py
@@ -10,12 +10,14 @@ mcp = FastMCP("doc_updates")
 API_BASE = "https://docs.westiedoubao.com/api"
 USER_AGENT = "doc-updates-app/1.0"
 
-async def make_api_request(url: str) -> dict[str, Any] | None:
+async def make_api_request(url: str, extra_headers: Optional[dict[str, str]] = None) -> dict[str, Any] | None:
     """向API发送请求，并进行适当的错误处理。"""
     headers = {
         "User-Agent": USER_AGENT,
         "Accept": "application/json"
     }
+    if extra_headers:
+        headers.update(extra_headers)
     async with httpx.AsyncClient() as client:
         try:
             response = await client.get(url, headers=headers, timeout=30.0)
@@ -154,7 +156,7 @@ async def get_usage_stats(
     if query_string:
         url = f"{url}?{query_string}"
     
-    data = await make_api_request(url)
+    data = await make_api_request(url, extra_headers={"x-admin-password": password})
     
     if not data or "error" in data:
         return f"无法获取使用统计数据：{data.get('error', '未知错误')}"

--- a/web/src/app/api/usage/auth/route.ts
+++ b/web/src/app/api/usage/auth/route.ts
@@ -1,25 +1,19 @@
 import { NextResponse } from 'next/server';
+import { validateAdminPassword } from '@/lib/adminAuth';
 
 export async function POST(request: Request) {
   try {
     const { password } = await request.json();
-    const correctPassword = process.env.ADMIN_PASSWORD;
+    const auth = validateAdminPassword(password);
 
-    if (!correctPassword) {
-      return NextResponse.json(
-        { error: '系统配置错误：未设置管理员密码' },
-        { status: 500 }
-      );
-    }
-
-    if (password === correctPassword) {
+    if (auth.ok) {
       return NextResponse.json({ success: true });
-    } else {
-      return NextResponse.json(
-        { error: '密码错误' },
-        { status: 401 }
-      );
     }
+
+    return NextResponse.json(
+      { error: auth.error },
+      { status: auth.status }
+    );
   } catch (error) {
     return NextResponse.json(
       { error: '验证过程出错' },

--- a/web/src/app/api/usage/route.ts
+++ b/web/src/app/api/usage/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { CosmosClient } from '@azure/cosmos';
 import { ClientSecretCredential } from '@azure/identity';
 import { logger } from '@/lib/logger';
+import { validateAdminPassword } from '@/lib/adminAuth';
 
 // Initialize Azure AD credentials
 const credential = new ClientSecretCredential(
@@ -17,17 +18,40 @@ const client = new CosmosClient({
 });
 
 export async function GET(request: Request) {
+  const auth = validateAdminPassword(request.headers.get('x-admin-password'));
+  if (!auth.ok) {
+    return NextResponse.json(
+      { error: auth.error },
+      { status: auth.status }
+    );
+  }
+
   const { searchParams } = new URL(request.url);
   const startTime = searchParams.get('startTime') || new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
   const endTime = searchParams.get('endTime') || new Date().toISOString();
   const excludeUsers = searchParams.get('excludeUsers') || '';
 
+  if (Number.isNaN(Date.parse(startTime)) || Number.isNaN(Date.parse(endTime))) {
+    return NextResponse.json(
+      { error: 'Invalid startTime or endTime' },
+      { status: 400 }
+    );
+  }
+
   // 处理要排除的用户列表
   const excludeUsersList = excludeUsers.split(',').map(user => user.trim()).filter(Boolean);
-  const userConditions = ['c.userInfo.name NOT LIKE \'anonymous\''];
-  if (excludeUsersList.length > 0) {
-    userConditions.push(...excludeUsersList.map(user => `c.userInfo.name != '${user}'`));
-  }
+  const userConditions = ['c.userInfo.name != @anonymousUser'];
+  const sharedParameters = [
+    { name: '@startTime', value: startTime },
+    { name: '@endTime', value: endTime },
+    { name: '@anonymousUser', value: 'anonymous' }
+  ];
+
+  excludeUsersList.forEach((user, index) => {
+    const parameterName = `@excludeUser${index}`;
+    userConditions.push(`c.userInfo.name != ${parameterName}`);
+    sharedParameters.push({ name: parameterName, value: user });
+  });
   const userFilterCondition = userConditions.join(' AND ');
 
   logger.info(`开始获取使用统计数据，时间范围: ${startTime} - ${endTime}，排除用户: ${excludeUsers}`);
@@ -38,50 +62,35 @@ export async function GET(request: Request) {
     // 获取每个用户的历史访问次数统计
     const userStatsQuery = {
       query: `SELECT c.userInfo.name, COUNT(1) AS recordCount FROM c WHERE ${userFilterCondition} AND c.path = "/" AND c.timestamp >= @startTime AND c.timestamp <= @endTime GROUP BY c.userInfo.name`,
-      parameters: [
-        { name: '@startTime', value: startTime },
-        { name: '@endTime', value: endTime }
-      ]
+      parameters: sharedParameters
     };
     const { resources: userStats } = await container.items.query(userStatsQuery).fetchAll();
 
     // 获取每日访问统计
     const dailyStatsQuery = {
       query: `SELECT SUBSTRING(c.timestamp, 0, 10) as date, COUNT(1) as count FROM c WHERE ${userFilterCondition} AND c.path = "/" AND c.timestamp >= @startTime AND c.timestamp <= @endTime GROUP BY SUBSTRING(c.timestamp, 0, 10)`,
-      parameters: [
-        { name: '@startTime', value: startTime },
-        { name: '@endTime', value: endTime }
-      ]
+      parameters: sharedParameters
     };
     const { resources: dailyStats } = await container.items.query(dailyStatsQuery).fetchAll();
 
     // 获取产品每日访问统计
     const productDailyStatsQuery = {
       query: `SELECT SUBSTRING(c.timestamp, 0, 10) as date, c.searchParams.product, COUNT(1) as count FROM c WHERE ${userFilterCondition} AND c.path = "/" AND c.timestamp >= @startTime AND c.timestamp <= @endTime GROUP BY SUBSTRING(c.timestamp, 0, 10), c.searchParams.product`,
-      parameters: [
-        { name: '@startTime', value: startTime },
-        { name: '@endTime', value: endTime }
-      ]
+      parameters: sharedParameters
     };
     const { resources: productDailyStats } = await container.items.query(productDailyStatsQuery).fetchAll();
 
     // 获取用户每日访问统计
     const userDailyStatsQuery = {
       query: `SELECT SUBSTRING(c.timestamp, 0, 10) as date, c.userInfo.name as name, COUNT(1) as count FROM c WHERE ${userFilterCondition} AND c.path = "/" AND c.timestamp >= @startTime AND c.timestamp <= @endTime GROUP BY SUBSTRING(c.timestamp, 0, 10), c.userInfo.name`,
-      parameters: [
-        { name: '@startTime', value: startTime },
-        { name: '@endTime', value: endTime }
-      ]
+      parameters: sharedParameters
     };
     const { resources: userDailyStats } = await container.items.query(userDailyStatsQuery).fetchAll();
 
     // 获取用户首次访问日期
     const firstVisitQuery = {
       query: `SELECT c.userInfo.name, MIN(SUBSTRING(c.timestamp, 0, 10)) as firstVisitDate FROM c WHERE ${userFilterCondition} AND c.path = "/" AND c.timestamp >= @startTime AND c.timestamp <= @endTime GROUP BY c.userInfo.name`,
-      parameters: [
-        { name: '@startTime', value: startTime },
-        { name: '@endTime', value: endTime }
-      ]
+      parameters: sharedParameters
     };
     const { resources: firstVisitData } = await container.items.query(firstVisitQuery).fetchAll();
 

--- a/web/src/app/usage/page.tsx
+++ b/web/src/app/usage/page.tsx
@@ -239,7 +239,16 @@ export default function UsagePage() {
     setLoading(true);
     setLoadingProgress(0);
     try {
-      const response = await fetch(`/api/usage?startTime=${startTime}&endTime=${endTime}&excludeUsers=${excludeUsers}`);
+      const params = new URLSearchParams({
+        startTime,
+        endTime,
+        excludeUsers
+      });
+      const response = await fetch(`/api/usage?${params.toString()}`, {
+        headers: {
+          'x-admin-password': password
+        }
+      });
       if (!response.ok) {
         throw new Error('Failed to fetch usage statistics');
       }

--- a/web/src/lib/adminAuth.ts
+++ b/web/src/lib/adminAuth.ts
@@ -1,0 +1,25 @@
+export function validateAdminPassword(password: string | null | undefined) {
+  const correctPassword = process.env.ADMIN_PASSWORD;
+
+  if (!correctPassword) {
+    return {
+      ok: false,
+      status: 500,
+      error: '系统配置错误：未设置管理员密码'
+    };
+  }
+
+  if (password !== correctPassword) {
+    return {
+      ok: false,
+      status: 401,
+      error: '密码错误'
+    };
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    error: null
+  };
+}


### PR DESCRIPTION
## Summary
- Require the admin password on `/api/usage`, not only on the client-side usage page
- Share password validation between `/api/usage/auth` and `/api/usage`
- Parameterize `excludeUsers` in Cosmos SQL queries instead of string-concatenating user input
- Validate `startTime` and `endTime` before querying

## Validation
- `npm run build` with dummy required env vars
- `git diff --check`

## Notes
- The usage page now sends the already-entered admin password in an `x-admin-password` header for the protected stats request.
- A stronger future version could replace this with an httpOnly short-lived admin session cookie.