### PR TITLE
Open source fragment links in update cards

### DIFF
--- a/web/scripts/audit-update-links.mjs
+++ b/web/scripts/audit-update-links.mjs
@@ -3,6 +3,11 @@
 const DEFAULT_BASE_URL = process.env.DOCS_BASE_URL || 'https://docs.westiedoubao.com';
 const URL_PATTERN = /https?:\/\/[^\s)\]}>"']+/g;
 const INTERNAL_LEARN_PATH_PARTS = ['/includes/', '/toc', '/model-matrix/', '/media/'];
+const LOCALE_PATTERN = /^[a-z]{2}-[a-z]{2}$/i;
+const SOURCE_REPOS = {
+  azureAiDocs: 'https://github.com/MicrosoftDocs/azure-ai-docs/blob/main/articles',
+  azureDocs: 'https://github.com/MicrosoftDocs/azure-docs/blob/main/articles'
+};
 
 function parseArgs(argv) {
   const args = {
@@ -66,6 +71,64 @@ function isLikelyInternalLearnUrl(url) {
   } catch {
     return false;
   }
+}
+
+function toSourcePath(parts) {
+  const sourcePath = parts.join('/');
+  if (!sourcePath) {
+    return '';
+  }
+
+  if (/\.[a-z0-9]+$/i.test(sourcePath)) {
+    return sourcePath;
+  }
+
+  return parts[parts.length - 1] === 'toc' ? `${sourcePath}.yml` : `${sourcePath}.md`;
+}
+
+function getLearnSourceUrl(url = '') {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== 'learn.microsoft.com') {
+      return '';
+    }
+
+    const parts = parsed.pathname.split('/').filter(Boolean);
+    if (parts.length > 0 && LOCALE_PATTERN.test(parts[0])) {
+      parts.shift();
+    }
+
+    if (parts[0] !== 'azure') {
+      return '';
+    }
+
+    const azurePath = parts.slice(1);
+    const [productRoot, ...rest] = azurePath;
+
+    if (!productRoot || rest.length === 0) {
+      return '';
+    }
+
+    if (productRoot === 'foundry' || productRoot === 'foundry-classic' || productRoot === 'ai-services') {
+      return `${SOURCE_REPOS.azureAiDocs}/${toSourcePath([productRoot, ...rest])}`;
+    }
+
+    if (productRoot === 'machine-learning' || productRoot.startsWith('iot-')) {
+      return `${SOURCE_REPOS.azureDocs}/${toSourcePath(azurePath)}`;
+    }
+
+    return '';
+  } catch {
+    return '';
+  }
+}
+
+function getOpenableDocUrl(url = '') {
+  if (!isLikelyInternalLearnUrl(url)) {
+    return url;
+  }
+
+  return getLearnSourceUrl(url) || url;
 }
 
 async function fetchJson(url) {
@@ -140,13 +203,15 @@ async function main() {
 
         for (const url of urls) {
           const internal = isLikelyInternalLearnUrl(url);
-          const result = internal ? { status: 'internal-source', ok: false } : await checkUrl(url);
+          const targetUrl = getOpenableDocUrl(url);
+          const result = await checkUrl(targetUrl);
           findings.push({
             product,
             page,
             updateId: update.id,
             title: update.title,
             url,
+            targetUrl,
             internal,
             status: result.status,
             ok: result.ok,
@@ -164,7 +229,8 @@ async function main() {
     pagesPerProduct: args.pages,
     totalLinks: findings.length,
     brokenLinks: broken.length,
-    internalSourceLinks: broken.filter(item => item.internal).length
+    internalSourceLinks: findings.filter(item => item.internal).length,
+    brokenInternalSourceLinks: broken.filter(item => item.internal).length
   };
 
   console.log(JSON.stringify({ summary, broken }, null, 2));

--- a/web/src/components/UpdateCard.tsx
+++ b/web/src/components/UpdateCard.tsx
@@ -5,7 +5,7 @@ import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import { toast } from 'sonner';
-import { getPrimaryDocUrl, isLikelyInternalLearnUrl } from '@/lib/docLinks';
+import { getOpenableDocUrl, getPrimaryDocUrl } from '@/lib/docLinks';
 
 interface UpdateCardProps {
   id: string;
@@ -181,23 +181,17 @@ export default function UpdateCard({
               components={{
                 a: ({node, ...props}) => {
                   const href = typeof props.href === 'string' ? props.href : '';
-                  if (isLikelyInternalLearnUrl(href)) {
-                    return (
-                      <span
-                        className="text-text-secondary/70 break-words"
-                        title="Internal Learn source fragment; not a public article link"
-                      >
-                        {props.children || href}
-                      </span>
-                    );
-                  }
+                  const openableHref = getOpenableDocUrl(href);
+                  const isSourceFileLink = href !== openableHref;
 
                   return (
                     <a
                       {...props}
+                      href={openableHref}
                       className="text-accent-secondary hover:text-accent-primary break-words"
                       target="_blank"
                       rel="noopener noreferrer"
+                      title={isSourceFileLink ? 'Open GitHub source file' : undefined}
                     />
                   );
                 }

--- a/web/src/lib/docLinks.ts
+++ b/web/src/lib/docLinks.ts
@@ -7,6 +7,12 @@ const INTERNAL_LEARN_PATH_PARTS = [
   '/media/'
 ];
 
+const LOCALE_PATTERN = /^[a-z]{2}-[a-z]{2}$/i;
+const SOURCE_REPOS = {
+  azureAiDocs: 'https://github.com/MicrosoftDocs/azure-ai-docs/blob/main/articles',
+  azureDocs: 'https://github.com/MicrosoftDocs/azure-docs/blob/main/articles'
+};
+
 export function extractUrls(markdown: string = '') {
   return Array.from(markdown.matchAll(URL_PATTERN))
     .map(match => match[0].replace(/[.,;:]+$/, ''))
@@ -34,6 +40,64 @@ export function isPublicLearnUrl(url: string = '') {
   } catch {
     return false;
   }
+}
+
+function toSourcePath(parts: string[]) {
+  const sourcePath = parts.join('/');
+  if (!sourcePath) {
+    return '';
+  }
+
+  if (/\.[a-z0-9]+$/i.test(sourcePath)) {
+    return sourcePath;
+  }
+
+  return parts[parts.length - 1] === 'toc' ? `${sourcePath}.yml` : `${sourcePath}.md`;
+}
+
+export function getLearnSourceUrl(url: string = '') {
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname !== 'learn.microsoft.com') {
+      return '';
+    }
+
+    const parts = parsed.pathname.split('/').filter(Boolean);
+    if (parts.length > 0 && LOCALE_PATTERN.test(parts[0])) {
+      parts.shift();
+    }
+
+    if (parts[0] !== 'azure') {
+      return '';
+    }
+
+    const azurePath = parts.slice(1);
+    const [productRoot, ...rest] = azurePath;
+
+    if (!productRoot || rest.length === 0) {
+      return '';
+    }
+
+    if (productRoot === 'foundry' || productRoot === 'foundry-classic' || productRoot === 'ai-services') {
+      return `${SOURCE_REPOS.azureAiDocs}/${toSourcePath([productRoot, ...rest])}`;
+    }
+
+    if (productRoot === 'machine-learning' || productRoot.startsWith('iot-')) {
+      return `${SOURCE_REPOS.azureDocs}/${toSourcePath(azurePath)}`;
+    }
+
+    return '';
+  } catch {
+    return '';
+  }
+}
+
+export function getOpenableDocUrl(url: string = '') {
+  if (!isLikelyInternalLearnUrl(url)) {
+    return url;
+  }
+
+  return getLearnSourceUrl(url) || url;
 }
 
 export function getPrimaryDocUrl(markdown: string = '') {


### PR DESCRIPTION
## Summary
- Convert internal Learn source-fragment URLs in update cards to openable GitHub source-file links.
- Keep public Learn article URLs pointing at Learn.
- Update the link audit script to validate the rendered target URL and report broken internal source links separately.

## Validation
- `npm run audit:links -- --product Microsoft-Foundry --pages 1 --fail-on-broken`
  - `totalLinks: 74`
  - `brokenLinks: 0`
  - `internalSourceLinks: 38`
  - `brokenInternalSourceLinks: 0`
- `npm run build` with required dummy environment variables
- Local Playwright smoke against Next dev server: verified the Foundry update card renders 4 prose anchors; 3 internal Learn include/source URLs point to `MicrosoftDocs/azure-ai-docs` GitHub source files, and the public `function-calling` Learn URL remains unchanged.