### PR TITLE
Fix path parsing when commit URL has extra query params (sha=live etc.)

### DIFF
--- a/commit_fetch.py
+++ b/commit_fetch.py
@@ -2,6 +2,7 @@
 import requests  # HTTP请求库，用于调用GitHub API
 from bs4 import BeautifulSoup  # HTML解析库（用于废弃的网页爬虫方法）
 import datetime  # 时间处理库
+from urllib.parse import urlparse, parse_qs  # URL 解析，避免手动 split 出错
 from logs import logger  # 日志记录器
 
 class CommitFetcher:  
@@ -30,13 +31,19 @@ class CommitFetcher:
         Returns:
             dict: commit时间到URL的映射字典，格式为 {datetime: url, ...}
         """
-        logger.info(f"Commit Root page: {root_commits_url}")  
+        logger.info(f"Commit Root page: {root_commits_url}")
 
         # 从URL中提取主题路径，用于后续过滤特定目录的文件变更
-        # 例如：从 "...?path=articles/ai-services/openai" 中提取 "articles/ai-services/openai"
-        parts = root_commits_url.split('path=')
-        # 获取 'path=' 后面的部分
-        self.topic_path = parts[1] if len(parts) > 1 else None
+        # 使用 urllib.parse 处理query string，正确支持多参数（例如 ?path=X&sha=live），
+        # 避免旧版本 `split('path=')` 在 path 参数后面还有其他参数时把它们粘在一起。
+        # 例：
+        #   .../commits?path=articles/foundry/openai              -> "articles/foundry/openai"
+        #   .../commits?path=articles/foundry/openai&sha=live     -> "articles/foundry/openai"
+        #   .../commits?sha=live&path=articles/foundry/openai     -> "articles/foundry/openai"
+        #   .../commits                                            -> None
+        query_params = parse_qs(urlparse(root_commits_url).query)
+        path_values = query_params.get('path', [])
+        self.topic_path = path_values[0] if path_values else None
 
         # 通过GitHub API获取commit列表的JSON响应
         # response = requests.get(root_commits_url, headers=headers).text  # 废弃的直接请求方式

--- a/test/test_commit_fetch_path_parse.py
+++ b/test/test_commit_fetch_path_parse.py
@@ -1,0 +1,100 @@
+"""
+Unit tests for CommitFetcher URL path parsing.
+
+Purpose: guard against regressions in `CommitFetcher.get_all_commits`'s
+path-extraction logic — specifically that `topic_path` is extracted correctly
+regardless of query-string parameter order and presence of extra params such
+as `sha=live`.
+
+These tests are pure-function checks: they exercise only the URL parsing
+branch of `get_all_commits`, so no GitHub API call is made.
+Run: `python -m pytest test/test_commit_fetch_path_parse.py -v`
+"""
+import os
+import sys
+from unittest.mock import patch
+
+# Allow running the test from the repo root or the test directory
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from commit_fetch import CommitFetcher
+
+
+def _extract_topic_path(url):
+    """Call get_all_commits far enough to compute topic_path, then bail out."""
+    fetcher = CommitFetcher()
+    # Short-circuit the HTTP call so we only exercise the parsing logic.
+    with patch.object(CommitFetcher, '_make_request_to_json', return_value=[]):
+        fetcher.get_all_commits(url, headers={})
+    return fetcher.topic_path
+
+
+def test_path_only():
+    """Baseline: existing config format with only ?path= param."""
+    url = "https://api.github.com/repos/MicrosoftDocs/azure-docs/commits?path=articles/ai-services/openai"
+    assert _extract_topic_path(url) == "articles/ai-services/openai"
+
+
+def test_path_with_trailing_slash():
+    """Trailing slash on path should be preserved (matches existing configs)."""
+    url = "https://api.github.com/repos/MicrosoftDocs/azure-docs/commits?path=articles/ai-services/openai/"
+    assert _extract_topic_path(url) == "articles/ai-services/openai/"
+
+
+def test_path_then_sha():
+    """pr repo case: ?path=X&sha=live must NOT swallow &sha=live into topic_path."""
+    url = "https://api.github.com/repos/MicrosoftDocs/azure-ai-docs-pr/commits?path=articles/foundry/openai&sha=live"
+    assert _extract_topic_path(url) == "articles/foundry/openai"
+
+
+def test_sha_then_path():
+    """Query-param order should not matter."""
+    url = "https://api.github.com/repos/MicrosoftDocs/azure-ai-docs-pr/commits?sha=live&path=articles/foundry/openai"
+    assert _extract_topic_path(url) == "articles/foundry/openai"
+
+
+def test_path_and_multiple_extra_params():
+    """Multiple extra params (sha, per_page, since) should all be ignored."""
+    url = (
+        "https://api.github.com/repos/MicrosoftDocs/azure-ai-docs-pr/commits"
+        "?path=articles/foundry/openai&sha=live&per_page=100&since=2026-06-01T00:00:00Z"
+    )
+    assert _extract_topic_path(url) == "articles/foundry/openai"
+
+
+def test_no_query_string():
+    """URL without any query string yields None (backward compatible)."""
+    url = "https://api.github.com/repos/MicrosoftDocs/azure-docs/commits"
+    assert _extract_topic_path(url) is None
+
+
+def test_only_other_params_no_path():
+    """URL with query but no path param yields None."""
+    url = "https://api.github.com/repos/MicrosoftDocs/azure-docs/commits?sha=live"
+    assert _extract_topic_path(url) is None
+
+
+if __name__ == "__main__":
+    # Allow running as a plain script too: `python test/test_commit_fetch_path_parse.py`
+    import traceback
+    tests = [
+        test_path_only,
+        test_path_with_trailing_slash,
+        test_path_then_sha,
+        test_sha_then_path,
+        test_path_and_multiple_extra_params,
+        test_no_query_string,
+        test_only_other_params_no_path,
+    ]
+    failed = 0
+    for t in tests:
+        try:
+            t()
+            print(f"PASS  {t.__name__}")
+        except AssertionError:
+            failed += 1
+            print(f"FAIL  {t.__name__}")
+            traceback.print_exc()
+    if failed:
+        sys.exit(1)
+    print(f"\nAll {len(tests)} tests passed.")


### PR DESCRIPTION
## Summary

- Replace fragile `root_commits_url.split('path=')[1]` in `CommitFetcher.get_all_commits` with `urllib.parse.urlparse` + `parse_qs`, so extra query parameters (e.g. `sha=live`, `per_page`, `since`) and parameter order no longer contaminate `topic_path`.
- Add pure-function unit tests covering both the existing URL shape and the new ones. Tests stub the HTTP call, so they run without a GitHub token / network.

## Why

The old code (line 37-39 of `commit_fetch.py`) does:

```python
parts = root_commits_url.split('path=')
self.topic_path = parts[1] if len(parts) > 1 else None
```

For every existing `target_config.json` entry this happens to work because the URL is always `.../commits?path=<X>` with nothing after. But for any URL that adds another query parameter after `path=`, the split silently swallows it into `topic_path`. Example:

```
Input:  .../commits?path=articles/foundry/openai&sha=live
Old:    topic_path = 'articles/foundry/openai&sha=live'
```

Downstream, `commit_fetch.py:165` uses `item['filename'].startswith(self.topic_path)` to decide whether a changed file belongs to the topic. Since no real filename ends with `&sha=live`, **every commit gets filtered out and no updates are ever pushed** — silently.

### Concrete motivation

The public `MicrosoftDocs/azure-ai-docs` GitHub repo is a mirror of the `main` branch of the internal `azure-ai-docs-pr` repo. Learn actually renders from the **`live` branch** of that internal repo, which the public mirror does not track. So there are documentation updates visible to customers on learn.microsoft.com that never appear as commits in the public mirror. Concrete recent example: `gpt-4o` is marked `Deprecated` on the Learn model retirement schedule page, but the include file on the public `main` branch still shows `GA`.

To monitor a non-default branch of a repo via the GitHub commits API you must pass `sha=<branch>` alongside `path=`, e.g.:

```
https://api.github.com/repos/<owner>/<repo>/commits?path=articles/foundry/openai&sha=live
```

Without this fix the path filter breaks the moment you add `sha=`. With this fix, `target_config.json` can accept URLs with arbitrary extra query params without changing any other code.

## What's not in this PR

- No changes to `target_config.json` — I only make the path parser tolerant of extra params. Any decision about *which* repos/branches to monitor (and any auth/token side of that) is left to the config owner.
- No changes to `spyder.py`, auth, or environment variables.

## Test plan

- [x] `python test/test_commit_fetch_path_parse.py` — all 7 tests pass.
  - Backward compat: `?path=X`, `?path=X/` (trailing slash), no query string, `?sha=X` alone → same behavior as before.
  - New capability: `?path=X&sha=Y`, `?sha=Y&path=X`, `?path=X&sha=Y&per_page=100&since=...` all extract `X` correctly.
- [x] Tests stub `_make_request_to_json`, so no network / no PAT needed.
- [x] Old-parse bug demonstrated empirically: `'https://...?path=articles/foundry/openai&sha=live'.split('path=')[1]` → `'articles/foundry/openai&sha=live'` (would break `startswith` filter).

## Files changed

- `commit_fetch.py` (+13, −5)
- `test/test_commit_fetch_path_parse.py` (new, ~100 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)