### PR TITLE
Ignore include_link_cache.json runtime artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ web/next-env.d.ts
 .claude/hook-debug.log
 .claude/hook-debug.log.*
 .claude/scheduled_tasks.json
+
+# include_link_resolver runtime cache (auto-generated at repo root by include_link_resolver.py)
+include_link_cache.json


### PR DESCRIPTION
## Summary
- Add `.gitignore` entry for `include_link_cache.json`, which `include_link_resolver.py` (added in #14) auto-generates at the repo root on first run.

## Why
After PR #14 merged, running the resolver locally or on a VM leaves `include_link_cache.json` as an untracked file in `git status`. It's a runtime cache (dedup + persisted URL resolutions), not code, so it should be gitignored — same pattern as `last_crawl_time.txt` already in the ignore list.

## Test plan
- [x] Confirmed file appears as untracked on a fresh checkout after `python eyes_on_docs.py` runs with `RESOLVE_INCLUDE_LINKS=true`
- [x] Verified `git check-ignore -v include_link_cache.json` matches the new rule after this patch